### PR TITLE
multilingual field on editing for geometric object count

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -244,6 +244,7 @@
       <name>gmd:transformationDimensionDescription</name>
       <name>gmd:orientationParameterDescription</name>
       <name>gmd:includedWithDataset</name>
+      <name>gmd:geometricObjectCount</name>
       <name parent="gmd:MD_Format">gmd:name</name>
       <name ancestor="gmd:thesaurusName">gmd:code</name>
       <name ancestor="gmd:aggregateDataSetIdentifier">gmd:code</name>


### PR DESCRIPTION
Do not add a multilingual block for gmd:geometricObjectCount (Fixing #SB-384)

Before:
![dev-sb384](https://cloud.githubusercontent.com/assets/594335/13596889/96e83dde-e515-11e5-8628-59fe7dc6dc36.png)

After:
![local-sb384](https://cloud.githubusercontent.com/assets/594335/13596898/9eebfbf6-e515-11e5-96c7-635f2531dd85.png)

Tests: runtime tested.