### PR TITLE
exclude attributeDescription from multilingual fields (SB-384)

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -246,6 +246,7 @@
       <name>gmd:orientationParameterDescription</name>
       <name>gmd:includedWithDataset</name>
       <name>gmd:geometricObjectCount</name>
+      <name>gmd:attributeDescription</name>
       <name parent="gmd:MD_Format">gmd:name</name>
       <name ancestor="gmd:thesaurusName">gmd:code</name>
       <name ancestor="gmd:aggregateDataSetIdentifier">gmd:code</name>


### PR DESCRIPTION
Need to exclude the `<gmd:attributeDescription>` and its descendant `<gco:RecordType>` from the multilingual fields. This to address the second part of the ticket SB-384 (see https://jira.swisstopo.ch/browse/GEOCAT_SB-384)

Tests: at runtime:
![sb384-attr-desc](https://cloud.githubusercontent.com/assets/594335/13745226/400905b6-e9ed-11e5-9f9a-c7f17c7dc6d3.png)

