### PR TITLE
SB-393: Fixed gmd:distributor creation

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1082,9 +1082,10 @@ public class EditLib {
         //     isOrType if element has substitutes and one of them should be chosen
         if (!type.isOrType()) {
             for(int i=0; i<type.getElementCount(); i++) {
-                String childName = type.getElementAt(i);
-                boolean childIsMandatory = type.getMinCardinAt(i) > 0;
-                boolean childIsSuggested = sugg.isSuggested(elemName, childName);
+                final String childName = type.getElementAt(i);
+                final boolean childIsMandatory = type.getMinCardinAt(i) > 0;
+                final boolean childIsSuggested = sugg.isSuggested(elemName, childName);
+                final boolean childIsFiltered = sugg.isFiltered(elemName, childName);
                 
                 if(Log.isDebugEnabled(Geonet.EDITORFILLELEMENT)) {
                     Log.debug(Geonet.EDITORFILLELEMENT,"####   - " + i + " element = " + childName);
@@ -1094,7 +1095,7 @@ public class EditLib {
                 
                 
                 
-                if (childIsMandatory || childIsSuggested) {
+                if ((childIsMandatory || childIsSuggested) && !childIsFiltered) {
                     
                     MetadataType elemType = schema.getTypeInfo(schema.getElementType(childName, elemName));
                     List<String> childSuggestion = sugg.getSuggestedElements(childName);
@@ -1105,7 +1106,7 @@ public class EditLib {
                         Log.debug(Geonet.EDITORFILLELEMENT,"####     - is or type = "+ elemType.isOrType());
                         Log.debug(Geonet.EDITORFILLELEMENT,"####     - has suggestion = "+ childHasOneSuggestion);
                         Log.debug(Geonet.EDITORFILLELEMENT,"####     - elem type list = " + elemType.getElementList());
-                        Log.debug(Geonet.EDITORFILLELEMENT,"####     - suggested types list = " + sugg.getSuggestedElements(childName));
+                        Log.debug(Geonet.EDITORFILLELEMENT,"####     - suggested types list = " + childSuggestion);
                     }
                     
                     //--- There can be 'or' elements with other 'or' elements inside them.

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaSuggestions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaSuggestions.java
@@ -64,29 +64,37 @@ public class SchemaSuggestions
 	//---
 	//--------------------------------------------------------------------------
 
-	public boolean isSuggested(String parent, String child)
+	private boolean isX(String parent, String child, String what)
 	{
-		Element fieldEl = htFields.get(parent);
+		final Element fieldEl = htFields.get(parent);
 
 		if (fieldEl == null)
 			return false;
 
 		@SuppressWarnings("unchecked")
-        List<Element> list = fieldEl.getChildren();
+		final List<Element> list = fieldEl.getChildren();
 
 		for (Element elem : list) {
-            if (elem.getName().equals("suggest")) {
-                String name = elem.getAttributeValue("name");
+			if (elem.getName().equals(what)) {
+				String name = elem.getAttributeValue("name");
 
-                if (child.equals(name)) {
-                    return true;
-                }
-            }
-        }
+				if (child.equals(name)) {
+					return true;
+				}
+			}
+		}
 
 		return false;
 	}
-	
+
+	public boolean isSuggested(String parent, String child)	{
+		return isX(parent, child, "suggest");
+	}
+
+	public boolean isFiltered(String parent, String child) {
+		return isX(parent, child, "filter");
+	}
+
 	/**
 	 * Return true if parent element is defined in suggestion
 	 * file and check that suggested elements are valid children

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/config-editor.xml
@@ -69,7 +69,7 @@
         data-template-type="contacts"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
-    <for name="gmd:distributor" addDirective="gc-add-sharedobject">
+    <for name="gmd:distributorContact" addDirective="gc-add-sharedobject">
       <directiveAttributes
         data-template-add-action="false"
         data-template-type="contacts"
@@ -180,6 +180,7 @@
     <name>gmd:graphicOverview</name>
     <name>gmd:includedWithDataset</name>
     <name>gmd:distributor</name>
+    <name>gmd:distributorContact</name>
   </fieldsWithFieldset>
 
   <multilingualFields>
@@ -330,6 +331,10 @@
       <flatModeExceptions>
         <for name="gmd:pointOfContact"/>
         <for name="gmd:distributor"/>
+        <for name="gmd:distributorContact"/>
+        <for name="gmd:distributionOrderProcess"/>
+        <for name="gmd:distributorFormat"/>
+        <for name="gmd:distributorTransferOptions"/>
         <for name="gmd:contact"/>
         <for name="gmd:processor"/>
         <for name="gmd:citedResponsibleParty"/>
@@ -594,6 +599,10 @@
       <flatModeExceptions>
         <for name="gmd:pointOfContact"/>
         <for name="gmd:distributor"/>
+        <for name="gmd:distributorContact"/>
+        <for name="gmd:distributionOrderProcess"/>
+        <for name="gmd:distributorFormat"/>
+        <for name="gmd:distributorTransferOptions"/>
         <for name="gmd:contact"/>
         <for name="gmd:processor"/>
         <for name="gmd:citedResponsibleParty"/>

--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/schema-suggestions.xml
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/schema-suggestions.xml
@@ -64,17 +64,17 @@
 		<suggest name="gmd:extent"/>
 	</field>
 	
-	<field name="gmd:extent" mode="xlinkOnly">
+	<field name="gmd:extent">
 		<suggest name="gmd:EX_Extent"/>
         <exception parent="gmd:EX_SpatialTemporalExtent"/>
         <exception parent="gmd:EX_TemporalExtent"/>
 	</field>
 	
-	<field name="che:revisionExtent" mode="xlinkOnly">
+	<field name="che:revisionExtent">
 		<suggest name="gmd:EX_Extent"/> 
 	</field>
 	
-	<field name="gmd:sourceExtent" mode="xlinkOnly">
+	<field name="gmd:sourceExtent">
 		<suggest name="gmd:EX_Extent"/> 
 	</field>
 	
@@ -134,43 +134,15 @@
 		<suggest name="xlink:href"/>
 	</field>
 	
-	<!-- xLink : as defined in XSD, all PropertyType having an
-		attribute group set to gco:ObjectReference could be linked
-		using xlink attributes. 
-		
-		For each elements allows user to use default editor or 
-		defined a remote resource using an xlink.
-		
-		To add a new xlink popup on an element add a new field
-		<field name="nsPrefix:elementName" mode="xlink|xlinkOnly"/>
-		
-		Different modes are available:
-		* xlink: will allow classic editor AND xlink popup
-		* xlinkOnly: will only allow xlink popup
-		
-		If not set default editor is used.
-	-->
-	<field name="gmd:contact" mode="xlinkOnly"/>
-	<field name="gmd:distributorContact" mode="xlinkOnly"/>
-	<field name="gmd:processor" mode="xlinkOnly"/>
-	<field name="gmd:citedResponsibleParty" mode="xlinkOnly"/>
-	<field name="gmd:pointOfContact" mode="xlinkOnly"/>
-	<field name="gmd:source" mode="xlinkOnly">
+	<field name="gmd:MD_Distributor">
+		<!-- Eventhough gmd:distributorContact is a mandatory field, we don't want to add it since
+		     we want the user to choose a sharedObject instead -->
+		<filter name="gmd:distributorContact"/>
+	</field>
+	<field name="gmd:source">
         <exception parent="gmd:LI_Lineage"/>
         <exception parent="gmd:LI_ProcessStep"/>
     </field>
-	
-	<field name="gmd:distributionFormat" mode="xlinkOnly"/>
-	<field name="gmd:distributorFormat" mode="xlinkOnly"/>
-	<field name="gmd:resourceFormat" mode="xlinkOnly"/>
-    <field name="gmd:descriptiveKeywords" mode="xlinkOnly"/>
-    <field name="srv:keywords" mode="xlinkOnly"/>
-	<!--<field name="gmd:referenceSystemInfo" mode="xlink"/>-->
-    <field name="srv:extent" mode="xlinkOnly"/>
-    <field name="gmd:spatialExtent" mode="xlinkOnly"/>
-    <field name="srv:keywords" mode="xlinkOnly"/>
-    <field name="gmd:userContactInfo" mode="xlinkOnly"/>
-	
 	
 	<field name="gmd:date">
 		<suggest name="gco:Date"/>


### PR DESCRIPTION
It was creating a gmd:CI_ResponsibleParty directly under the gmd:distributor.
Added a filter capability in the schema-suggestion.xml file to not create the
gmd:distributorContact, but to let the user create it using sharedObjects.