### PR TITLE
swiss profile - fixing transformation (sb-423)

### DIFF
--- a/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/layout.xsl
+++ b/schemas/iso19139.che/src/main/plugin/iso19139.che/layout/layout.xsl
@@ -171,7 +171,7 @@
       <xsl:with-param name="type"
         select="gn-fn-metadata:getFieldType($editorConfig, name(),
         name($theElement))"/>
-      <xsl:with-param name="name" select="if ($isEditing) then $theElement/gn:element/@ref else ''"/>
+      <xsl:with-param name="name" select="if ($isEditing = true) then $theElement/gn:element/@ref else ''"/>
       <xsl:with-param name="editInfo" select="$theElement/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>
       <!-- TODO: Handle conditional helper -->


### PR DESCRIPTION
In edit mode, the current XSL form:

```xsl
<xsl:select="if (boolean) ...">
```

does not seem to work. It needs to be explicitely compared to true, or this leads to the following error in GN when XSL-transforming:

"An empty sequence is not allowed as the value of parameter $name"

Tests:
- utests: testsuite (on schemas/) OK
- runtime tested on both reported MD (service md.edit): OK.