### PR TITLE
Fixing publish / unpublish logic (SB-434)

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/Publish.java
@@ -267,9 +267,7 @@ public class Publish {
             for (Integer operationId : operationIds) {
                 try {
                     if (publish) {
-                        if (!dataManager.setOperation(serviceContext, metadataId, groupId, operationId)) {
-                            return false;
-                        }
+                        dataManager.setOperation(serviceContext, metadataId, groupId, operationId);
                     } else {
                         dataManager.unsetOperation(serviceContext, metadataId, groupId, operationId);
                     }


### PR DESCRIPTION
If publishing, a test on the setOperation was made, returning false if the operation could not be added to the operationallowed (which occurs if the operation is already set in the db).

Returning false leads to missing operations in the table, making it impossible to actually publish a md, even if the user has the right to publish it.

IMHO the behaviour has to be coherent between publish and unpublish.

Tests:
* runtime, using same db state for the tested md (id: 2001525)
* testsuite on the whole services module is broken, and somehow hangs in
   maven.
* PublishTest.java suite is OK

Note:
This patch could be backported to gn upstream, if relevant.