### PR TITLE
Fix MD language corruption

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/IndexingTask.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.kernel.search.index;
 
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
 import jeeves.transaction.TransactionManager;
 import jeeves.transaction.TransactionTask;
 import org.fao.geonet.ApplicationContextHolder;
@@ -57,7 +59,10 @@ public class IndexingTask extends QuartzJobBean {
     private ConfigurableApplicationContext applicationContext;
     @Autowired
     private DataManager _dataManager;
-
+    @Autowired
+    private ConfigurableApplicationContext context;
+    @Autowired
+    private ServiceManager serviceManager;
 
     private void indexRecords() {
         ApplicationContextHolder.set(applicationContext);
@@ -95,7 +100,11 @@ public class IndexingTask extends QuartzJobBean {
     }
 
     @Override
-    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+    protected void executeInternal(JobExecutionContext jobContext) throws JobExecutionException {
+        ServiceContext serviceContext = serviceManager.createServiceContext("indexing", context);
+        serviceContext.setLanguage("ger");
+        serviceContext.setAsThreadLocal();
+
         if (Log.isDebugEnabled(Geonet.INDEX_ENGINE)) {
             Log.debug(Geonet.INDEX_ENGINE, "Indexing task / Start at: "
                     + new Date() + ". Checking if any records need to be indexed ...");

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -340,14 +340,13 @@ public final class XslUtil
     	if(iso3LangCode==null || iso3LangCode.length() == 0) {
     		return twoCharLangCode(Geonet.DEFAULT_LANGUAGE);
     	} else {
+            if(iso3LangCode.equalsIgnoreCase("FRA")) {
+                return "FR";
+            }
 
-    	if(iso3LangCode.equalsIgnoreCase("FRA")) {
-    		return "FR";
-    	}
-
-    	if(iso3LangCode.equalsIgnoreCase("DEU")) {
-    		return "DE";
-    	}
+            if(iso3LangCode.equalsIgnoreCase("DEU")) {
+                return "DE";
+            }
             String iso2LangCode = null;
 
             try {
@@ -365,6 +364,7 @@ public final class XslUtil
             }
 
             if(iso2LangCode == null) {
+                Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
                 return iso3LangCode.substring(0,2);
             } else {
                 return iso2LangCode;


### PR DESCRIPTION
When tomcat was restarted and the first MD was viewed by a user, the
MD was re-indexed (to update the view counter) in a Quartz thread.
This Quartz thread never had his ServiceContext initialized and that
made the ISO3 to ISO2 conversion unable to convert the codes.

I guess something later on is setting the ServiceContext for the Quartz
thread and the problem doesn't happen anymore, because only the first MD
that is viewed is corrupted.